### PR TITLE
Footer and tab header update

### DIFF
--- a/app/templates/layout/index.html
+++ b/app/templates/layout/index.html
@@ -9,7 +9,7 @@
     <meta name="author" content="Coffee Source">
     <link rel="icon" href="{% static 'img/favicon.ico' %}">
 
-    <title>{% block title %}{% endblock title %} | Coffee Source</title>
+    <title>{% block title %}{% endblock title %} | SteemLogs.Info</title>
 
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" crossorigin="anonymous">
     <link href="{% static 'css/libs/bootstrap.min.css' %}" rel="stylesheet" type='text/css'>
@@ -57,7 +57,7 @@
     </main>
 
     <footer class="container">
-      <p>&copy; Coffee Source</p>
+      <p>&copy; SteemLogs</p>
     </footer>
 
     <script src="{% static 'js/libs/jquery-3.2.1.min.js' %}"></script>


### PR DESCRIPTION
Deleted last mentions of Coffeesource Branding, replaced with SteemLogs.Info branding.